### PR TITLE
Feature: Use NetworkABC base class

### DIFF
--- a/template_model_implamentation/cnn_spinodal.py
+++ b/template_model_implamentation/cnn_spinodal.py
@@ -1,34 +1,40 @@
-### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework. 
-### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework. 
+from template import NetworkABC
 import tensorflow as tf
 import numpy as np
 
 
-class Network:
-
+class Network(NetworkABC):
     def __init__(self):
         pass
 
     callbacks = [
-                        tf.keras.callbacks.EarlyStopping(monitor='val_loss', min_delta =0.0001, patience=15, restore_best_weights = True),
-                        tf.keras.callbacks.ModelCheckpoint('./',  monitor='val_loss', save_best_only=True, save_weights_only=True)
-                        ]                                              ##list of callbacks to be used in model.
-    metrics   = [
-                    tf.keras.metrics.BinaryAccuracy(name = "acc"), 
-                    tf.keras.metrics.AUC(name = "AUC")
-                    ]                                              ##list of metrics to be used
-    compile_args = {'optimizer':tf.keras.optimizers.Adam(0.001),
-              'loss':tf.keras.losses.BinaryCrossentropy(from_logits=True),
-              'metrics':metrics}                      ##dictionary of the arguments to be passed to the method compile()
+        tf.keras.callbacks.EarlyStopping(
+            monitor="val_loss", min_delta=0.0001, patience=15, restore_best_weights=True
+        ),
+        tf.keras.callbacks.ModelCheckpoint(
+            "./", monitor="val_loss", save_best_only=True, save_weights_only=True
+        ),
+    ]  ##list of callbacks to be used in model.
+    metrics = [
+        tf.keras.metrics.BinaryAccuracy(name="acc"),
+        tf.keras.metrics.AUC(name="AUC"),
+    ]  ##list of metrics to be used
+    compile_args = {
+        "optimizer": tf.keras.optimizers.Adam(0.001),
+        "loss": tf.keras.losses.BinaryCrossentropy(from_logits=True),
+        "metrics": metrics,
+    }  ##dictionary of the arguments to be passed to the method compile()
     fit_args = {
-                    'shuffle': True,
-                    'validation_split': 0.2,
-                    'epochs': 200,
-                    'callbacks': callbacks,
-                    'batch_size': 100,
-                    }                      ##dictionary of the arguments to be passed to the method fit()
+        "shuffle": True,
+        "validation_split": 0.2,
+        "epochs": 200,
+        "callbacks": callbacks,
+        "batch_size": 100,
+    }  ##dictionary of the arguments to be passed to the method fit()
 
-    compatible_datasets = ["spinodal"]         ## we would also ask you to add a list of the datasets that would be compatible with your implementation 
+    compatible_datasets = [
+        "spinodal"
+    ]  ## we would also ask you to add a list of the datasets that would be compatible with your implementation
 
     def preprocessing(self, in_data):
         """
@@ -36,28 +42,28 @@ class Network:
         and after the application of all the preprocessing routin, it should return the modified data
         in the desired shapes
         """
-        out_data=np.reshape(in_data,(len(in_data),20,20,1))
+        out_data = np.reshape(in_data, (len(in_data), 20, 20, 1))
 
         return out_data
 
-
-    def model(self, ds, shape, save_model_png = False):
+    def model(self, ds, shape, save_model_png=False):
 
         model = tf.keras.Sequential()
-        model.add(tf.keras.layers.Conv2D(15, (3, 3), activation='relu',input_shape=shape,strides=(1,1), padding='same'))
+        model.add(
+            tf.keras.layers.Conv2D(
+                15, (3, 3), activation="relu", input_shape=shape, strides=(1, 1), padding="same"
+            )
+        )
         model.add(tf.keras.layers.MaxPooling2D((2, 2)))
-        model.add(tf.keras.layers.Conv2D(15, (3, 3), activation='relu', padding='same'))
+        model.add(tf.keras.layers.Conv2D(15, (3, 3), activation="relu", padding="same"))
         model.add(tf.keras.layers.MaxPooling2D((2, 2)))
-        model.add(tf.keras.layers.Conv2D(25, (3, 3), activation='relu', padding='same'))
+        model.add(tf.keras.layers.Conv2D(25, (3, 3), activation="relu", padding="same"))
         model.add(tf.keras.layers.Dropout(0.4))
         model.add(tf.keras.layers.Flatten())
-        model.add(tf.keras.layers.Dense(10, activation='relu'))
-        model.add(tf.keras.layers.Dense(1, activation='sigmoid'))
-        
+        model.add(tf.keras.layers.Dense(10, activation="relu"))
+        model.add(tf.keras.layers.Dense(1, activation="sigmoid"))
+
         if save_model_png:
-            tf.keras.utils.plot_model(model, to_file='./{}_model.png'.format(ds))
-        
-        
+            tf.keras.utils.plot_model(model, to_file="./{}_model.png".format(ds))
+
         return model
-
-

--- a/template_model_implamentation/fcn.py
+++ b/template_model_implamentation/fcn.py
@@ -1,46 +1,49 @@
 ##################################
 ###  FCN EXAMPLE IMPELEMTATION ###
-
+from template import NetworkABC
 
 import tensorflow as tf
 import numpy as np
 
-class Network:
 
-    metrics =   [
-                    tf.keras.metrics.BinaryAccuracy(name = "acc"), 
-                    tf.keras.metrics.AUC(name = "AUC")
-                    ]
+class Network(NetworkABC):
 
-    compile_args = {'optimizer': tf.keras.optimizers.Adam(0.001),
-                        'loss': tf.keras.losses.BinaryCrossentropy(),
-                        'metrics': metrics,
-                        }
+    metrics = [tf.keras.metrics.BinaryAccuracy(name="acc"), tf.keras.metrics.AUC(name="AUC")]
+
+    compile_args = {
+        "optimizer": tf.keras.optimizers.Adam(0.001),
+        "loss": tf.keras.losses.BinaryCrossentropy(),
+        "metrics": metrics,
+    }
     callbacks = [
-                        tf.keras.callbacks.EarlyStopping(monitor='val_loss', min_delta =0.0001, patience=15, restore_best_weights = True),
-                        tf.keras.callbacks.ModelCheckpoint('./',  monitor='val_loss', save_best_only=True, save_weights_only=True)
-                        ] 
-    fit_args =  {
-                    'shuffle': True,
-                    'validation_split': 0.2,
-                    'epochs': 100,
-                    'callbacks': callbacks,
-                    'batch_size': 300,
-                    }
+        tf.keras.callbacks.EarlyStopping(
+            monitor="val_loss", min_delta=0.0001, patience=15, restore_best_weights=True
+        ),
+        tf.keras.callbacks.ModelCheckpoint(
+            "./", monitor="val_loss", save_best_only=True, save_weights_only=True
+        ),
+    ]
+    fit_args = {
+        "shuffle": True,
+        "validation_split": 0.2,
+        "epochs": 100,
+        "callbacks": callbacks,
+        "batch_size": 300,
+    }
 
     compatible_datasets = ["top", "spinodal", "EOSL"]
 
     def preprocessing(self, in_data):
-        ''' in_data: numpy array. Input to be preprocessed
-            returns flattened array.
-        '''
+        """in_data: numpy array. Input to be preprocessed
+        returns flattened array.
+        """
         if len(in_data.shape[1:]) > 1:
-            out_data = np.reshape(in_data, (len(in_data), in_data.shape[1]*in_data.shape[2]))
+            out_data = np.reshape(in_data, (len(in_data), in_data.shape[1] * in_data.shape[2]))
             return out_data
         return in_data
 
-    def model(self, ds, shape, save_model_png = False): 
-        
+    def model(self, ds, shape, save_model_png=False):
+
         """
         Builds sequential model.
         ds: string. Name of the dataset that will be used as input for the model;
@@ -48,19 +51,18 @@ class Network:
         save_model_png = bool. Save .png of the model in the execution dir.
         """
 
-        if ds == 'airshower' or ds == 'belle':
+        if ds == "airshower" or ds == "belle":
             print("Dataset {} has too many input datasets.".format(self.ds))
             return
 
         model = tf.keras.Sequential()
-        model.add(tf.keras.Input(shape = shape))
+        model.add(tf.keras.Input(shape=shape))
         tf.keras.layers.BatchNormalization()
         for l in range(15):
-            model.add(tf.keras.layers.Dense(256, activation = 'relu'))  ##add hidden layers
-        model.add(tf.keras.layers.Dense(1, activation = 'sigmoid'))         ##add output layer
-    
+            model.add(tf.keras.layers.Dense(256, activation="relu"))  ##add hidden layers
+        model.add(tf.keras.layers.Dense(1, activation="sigmoid"))  ##add output layer
+
         if save_model_png:
-            tf.keras.utils.plot_model(model, to_file='./{}_model.png'.format(ds))
+            tf.keras.utils.plot_model(model, to_file="./{}_model.png".format(ds))
 
         return model
-

--- a/template_model_implamentation/gcn_belle.py
+++ b/template_model_implamentation/gcn_belle.py
@@ -1,9 +1,9 @@
 import tensorflow as tf
 from tensorflow.keras import layers
-import numpy as np
+from template import NetworkABC
 
 
-class Network:
+class Network(NetworkABC):
 
     callbacks = [
         tf.keras.callbacks.EarlyStopping(
@@ -136,9 +136,9 @@ def get_model(units=128, num_nodes=100, num_features=8, num_pdg=540, emb_size=8)
         name="embedding",
     )(pdg_input)
 
-    adjacency_l = AdjacencyMatrixFromMothers(
-        add_diagonal=True, symmetrize=True, normalize=True
-    )(adjacency_input)
+    adjacency_l = AdjacencyMatrixFromMothers(add_diagonal=True, symmetrize=True, normalize=True)(
+        adjacency_input
+    )
 
     feat_pdg_input = layers.Concatenate()([pdg_l, feature_input])
 

--- a/template_model_implamentation/main.py
+++ b/template_model_implamentation/main.py
@@ -1,11 +1,10 @@
-### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework. 
-##	William Korcari: william.korcari@desy.de 	
+### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework.
+##	William Korcari: william.korcari@desy.de
 
 import erum_data_data as edd
-import tensorflow as tf
 
 ##	Please add the model generating function and the preprocessing function in that file.
-#from fcn import Network		    	#import your model function
+# from fcn import Network		    	#import your model function
 from gcn_belle import Network
 
 ##	utils.py is the file that contains all the self-built methods of this script.
@@ -20,30 +19,28 @@ from utils import test_f1_score
 
 nn = Network()
 
-datasets =  nn.compatible_datasets
+datasets = nn.compatible_datasets
 
 for ds in datasets:
 
-	X_train, y_train  = edd.load(ds, dataset='train', cache_dir = './'+ ds, cache_subdir = 'datasets')
-	X_test, y_test = edd.load(ds, dataset='test', cache_dir = './'+ ds, cache_subdir = 'datasets')
+    X_train, y_train = edd.load(ds, dataset="train", cache_dir="./" + ds, cache_subdir="datasets")
+    X_test, y_test = edd.load(ds, dataset="test", cache_dir="./" + ds, cache_subdir="datasets")
 
-	x_train = nn.preprocessing(X_train)
-	x_test = nn.preprocessing(X_test)
+    x_train = nn.preprocessing(X_train)
+    x_test = nn.preprocessing(X_test)
 
-	model = nn.model(ds, shapes = [x.shape[1:] for x in x_train])
-	model.compile(**nn.compile_args)
-	history = model.fit(x = x_train, y = y_train, **nn.fit_args)
+    model = nn.model(ds, shapes=[x.shape[1:] for x in x_train])
+    model.compile(**nn.compile_args)
+    history = model.fit(x=x_train, y=y_train, **nn.fit_args)
 
-	##	From here on, one should be able to use already defined methods as showed in the following lines. 
-	##	Let us know if you face any issues with that.
+    ##	From here on, one should be able to use already defined methods as showed in the following lines.
+    ##	Let us know if you face any issues with that.
 
-	#training history plots
-	train_plots(history, ds, True)
+    # training history plots
+    train_plots(history, ds, True)
 
-	#evaluation plots and scores
-	y_pred = model.predict(x_test).ravel()
-	roc_auc(y_pred, y_test, ds, True)
-	test_accuracy(y_pred, y_test, ds)
-	test_f1_score(y_pred, y_test, ds)
-
-
+    # evaluation plots and scores
+    y_pred = model.predict(x_test).ravel()
+    roc_auc(y_pred, y_test, ds, True)
+    test_accuracy(y_pred, y_test, ds)
+    test_f1_score(y_pred, y_test, ds)

--- a/template_model_implamentation/template.py
+++ b/template_model_implamentation/template.py
@@ -1,37 +1,52 @@
-### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework. 
-### This is a template file meant to be a guideline to smooth out the implementation of our models in the same framework. 
-import tensorflow as tf
-import numpy as np
+# This is a template file meant to be a guideline to smooth
+# out the implementation of our models in the same framework.
+from abc import ABCMeta, abstractmethod
+from typing import List, Dict
 
 
-class Network:
+class NetworkABC(metaclass=ABCMeta):
+    @property
+    def callbacks(self) -> List:
+        # list of callbacks to be used in model.
+        return []
 
-    def __init__(self):
+    @property
+    def metrics(self) -> List:
+        # list of metrics to be used
+        return []
+
+    @property
+    def compile_args(self) -> Dict:
+        # dictionary of the arguments to be passed to the method compile()
+        return {"metrics": self.metrics}
+
+    @property
+    def fit_args(self) -> Dict:
+        # dictionary of the arguments to be passed to the method fit()
+        return {"callbacks": self.callbacks}
+
+    @property
+    @abstractmethod
+    def compatible_datasets(self) -> List:
+        # we would also ask you to add a list of the datasets that
+        # would be compatible with your implementation
         pass
-
-    callbacks = []                                              ##list of callbacks to be used in model.
-    metrics   = []                                              ##list of metrics to be used
-    compile_args = {'metrics': metrics}                      ##dictionary of the arguments to be passed to the method compile()
-    fit_args = {'callbacks': callbacks}                      ##dictionary of the arguments to be passed to the method fit()
-
-    compatible_datasets = []         ## we would also ask you to add a list of the datasets that would be compatible with your implementation 
 
     def preprocessing(self, in_data):
         """
-        Method should take as an input the list of datasets to be used as an iput for the model
+        Method should take as an input the list of datasets to be used as an input for the model
         and after the application of all the preprocessing routin, it should return the modified data
         in the desired shapes
         """
-        
-        #   write your preprocessing routin here
-        return out_data
 
+        # write your preprocessing routin here
+        return in_data
 
-    def model(self, ds, shapes = None):
-        '''
-         model should take shapes of the input datasets (not counting the number of events)
-         and return the desired model
-        '''
-        #   write your model here
-        return model
-
+    @abstractmethod
+    def model(self, ds, shapes=None):
+        """
+        model should take shapes of the input datasets (not counting the number of events)
+        and return the desired model
+        """
+        # write your model here
+        pass


### PR DESCRIPTION
Hi @WilliamKorcari and @erikbuh ,

I've added a `NetworkABC` base class with some structure. `Network`s should inherit from it and are currently forced to implement `compatible_datasets` and a `model`. (I thought these two should be required, while the other can be optional):

```python
class Network(NetworkABC):
    compatible_datasets = ["datasetA", "datasetB"]
    
    def model(self, ds, shapes=None):
        model = ...
        return model
```

Additional features in this PR:

- remove unused imports (mainly: `import numpy as np` 
- make all (already implemented) `Network` implementations inherit from `NetworkABC`
- lint (using `black`) for readability (I can revert this if you don't like it)
- `preprocessing` method does not need to be implemented, if not implemented it will do nothing and just pass the `in_data` as it is through

Additional ideas: 

- Currently the `compile_args`and `fit_args` *have to be overwritten* in order to work properly. If you want
I can try to think of a less brute-force approach for these two properties.
- What do you think about some useful predefined `compile_args`and `fit_args` defaults: 
e.g. optimiser: `Adam(1e-3)` or `batch_size=1<<6`?

Thank you very much for reading and reviewing, let me know what you think! :) 

Cheers, Peter

Closes #6