### PR TITLE
fix import decorator

### DIFF
--- a/erum_data_data/utils.py
+++ b/erum_data_data/utils.py
@@ -37,127 +37,21 @@ def _check_md5(fpath):
     return hash_md5.hexdigest()
 
 
-_VERSION_TMPL = r"^(?P<major>{v})" r"\.(?P<minor>{v})" r"\.(?P<patch>{v})$"
-_VERSION_WILDCARD_REG = re.compile(_VERSION_TMPL.format(v=r"\d+|\*"))
-_VERSION_RESOLVED_REG = re.compile(_VERSION_TMPL.format(v=r"\d+"))
+class verbose_import:
+    def __init__(self, package):
+        self.package = package
 
+    def __call__(self, cls, *args, **kwargs):
+        try:
+            import_module(self.package)
+            console.print(f":tada: Successfully imported: [bold]{self.package}")
 
-def _str_to_version(version_str: str, allow_wildcard: bool = False):
-    """
-    Return the tuple (major, minor, patch) version extracted from the str.
-    """
-    reg = _VERSION_WILDCARD_REG if allow_wildcard else _VERSION_RESOLVED_REG
-    res = reg.match(version_str)
-    if not res:
-        msg = f"Invalid version '{version_str}'. Format should be x.y.z"
-        if allow_wildcard:
-            msg += " with {x,y,z} being digits or wildcard."
-        else:
-            msg += " with {x,y,z} being digits."
-        raise ValueError(msg)
-    return tuple(
-        v if v == "*" else int(v)
-        for v in [res.group("major"), res.group("minor"), res.group("patch")]
-    )
+            @functools.wraps(cls)
+            def req(*args, **kwargs):
+                return cls(*args, **kwargs)
 
-
-class Version:
-    def __init__(self, version: str):
-        self.major, self.minor, self.patch = _str_to_version(version)
-
-    @property
-    def tuple(self):
-        return self.major, self.minor, self.patch
-
-    def __str__(self) -> str:
-        return "{}.{}.{}".format(*self.tuple)
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}('{str(self)}')"
-
-    def _validate(self, other):
-        if isinstance(other, str):
-            return Version(other)
-        elif isinstance(other, Version):
-            return other
-        raise AssertionError(f"{other} (type {type(other)}) cannot be compared to version.")
-
-    def __eq__(self, other):
-        other = self._validate(other)
-        return self.tuple == other.tuple
-
-    def __ne__(self, other):
-        other = self._validate(other)
-        return self.tuple != other.tuple
-
-    def __lt__(self, other):
-        other = self._validate(other)
-        return self.tuple < other.tuple
-
-    def __le__(self, other):
-        other = self._validate(other)
-        return self.tuple <= other.tuple
-
-    def __gt__(self, other):
-        other = self._validate(other)
-        return self.tuple > other.tuple
-
-    def __ge__(self, other):
-        other = self._validate(other)
-        return self.tuple >= other.tuple
-
-
-def require_software(**kwargs):
-    """
-    @require_software(
-        notexisting="1.1.0",
-        tensorflow="2.15.0",
-        numpy="1.1.0",
-        matplotlib="2.0.0",
-        force_env=True,
-    )
-    class CNN:
-        pass
-    """
-
-    def decorator(cls):
-        force_env = kwargs.pop("force_env", False)
-        corrupted_env = []
-        console.print(f"[bold green]Checking software requirements for {cls.__name__}...\n")
-        for package, version in kwargs.items():
-            assert isinstance(package, str)
-            assert isinstance(version, str)
-            required = Version(version)
-            try:
-                pkg = import_module(package)
-            except ImportError:
-                console.print(
-                    f"\t:cross_mark: {package} - {required} is not installed! "
-                    f"Install package: `pip install '{package}=={version}'`"
-                )
-                corrupted_env.append(package)
-                continue
-            current = Version(pkg.__version__)
-            if current < required:
-                console.print(
-                    f"\t:cross_mark: {package} - {current} (required: {required}) is outdated! "
-                    f"Try upgrading: `pip install '{package}>={version}'`"
-                )
-                corrupted_env.append(package)
-            else:
-                console.print(
-                    f"\t:white_heavy_check_mark: {package} - {current} (required: {required}) is installed"
-                )
-        if corrupted_env and force_env:
-            raise Exception(
-                f"Environment is not properly set up ({len(corrupted_env)} packages are not installed or outdated). "
-                "Please install the required packages!"
-            )
-
-        @functools.wraps(cls)
-        def wrapper(*args, **kwargs):
-            return cls(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
+        except ImportError as e:
+            raise ImportError(
+                f"`{self.package}` is not installed! Try: `pip install '{self.package}'`"
+            ) from e
+        return req


### PR DESCRIPTION
Hi,

I wanted to update this decorator already some time ago. My previous implementation was not very safe, I did not consider that many packages do not follow `semver` formatting for releases. Therefore I degraded this decorator to provide only verbose import functionality, which still can be very useful in the future.

Here is the new decorator in action:

```python
In [1]: from erum_data_data.utils import verbose_import

In [2]: @verbose_import("numpy")
   ...: @verbose_import("tensorflow")
   ...: @verbose_import("matplotlib")
   ...: def sqrt(x):
   ...:     return numpy.sqrt(x)
   ...:
🎉 Successfully imported: matplotlib
🎉 Successfully imported: tensorflow
🎉 Successfully imported: numpy

In [3]: @verbose_import("existsonlyinmydreams")
   ...: def sqrt(x):
   ...:     return numpy.sqrt(x)
   ...:
...longer stack trace here...
ImportError: `existsonlyinmydreams` is not installed! Try: `pip install 'existsonlyinmydreams'`
```

Best, Peter