### PR TITLE
fix awkward0 import

### DIFF
--- a/erum_data_data/tt_graph_utils.py
+++ b/erum_data_data/tt_graph_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import awkward
+import awkward0 as awkward
 import uproot_methods
 import multiprocessing as mp
 import platform


### PR DESCRIPTION
Small fix for the `awkward-array` naming transition. Now people can still do: `pip install awkward0` and run the code :)

Best, Peter