### PR TITLE
fix metric benchmarking

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -82,7 +82,7 @@ class Benchmark:
             dict(
                 filename="history.json",
                 mode="w",
-                content=lambda self: history,
+                content=lambda self: {k: [v[-1]] for k, v in history.items()},
             ),
         )
         info = HistoryInfo(cwd=self.cwd)
@@ -108,8 +108,7 @@ class Benchmark:
         for rec in self.records:
             history = pd.read_json(os.path.join(self.wd, rec, "history.json"))
             history["Timestamp"] = rec
-            # report only best: `.max()`
-            data = data.append(history.max(), ignore_index=True)
+            data = data.append(history, ignore_index=True)
         order = ["Timestamp"] + sorted(list(set(data.columns) - {"Timestamp"}))
         data = data.reindex(order, axis=1)
         data = data.sort_values(by=sort_by, ascending=False)

--- a/models/main.py
+++ b/models/main.py
@@ -32,7 +32,7 @@ for ds in datasets:
     print(model.summary())
     history = model.fit(x=x_train, y=y_train, **nn.fit_args)
 
-    benchmark = Benchmark(dataset=ds.name, network=f"{ds.name}_DNN")
+    benchmark = Benchmark(dataset=ds.name, network=model.name)
     benchmark.snapshot(history=history.history)
     # print summary table or all recorded trainings
     benchmark.summary_report()


### PR DESCRIPTION
Hi @erikbuh ,

Sorry for this PR. I had to fix how the metrics are displayed in the end. First I did `.max()` on the data frame, which is certainly not a good idea for a metric like `loss`... Now I moved to just benchmarking the metrics of the last epoch. This should be safe now :)

Best, Peter