### PR TITLE
Implement `load_graph` for Belle dataset

### DIFF
--- a/erum_data_data/belle_graph_utils.py
+++ b/erum_data_data/belle_graph_utils.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+"""
+Some helper functions for the graph version of the Belle dataset
+"""
+
+def adjacency_matrix_from_mothers_np(mother_indices, symmetrize=True, add_diagonal=True):
+    """
+    Calculate adjacency matrix from mother indices (numpy version). Assumes
+    that mother indices are -1 padded.
+    """
+    N = mother_indices.shape[1]
+    adj = np.eye(N + 1, dtype=np.int8)[mother_indices][:, :, :-1]
+    if symmetrize:
+        adj = adj + np.transpose(adj, (0, 2, 1))
+    if add_diagonal:
+        adj += np.where(
+            (mother_indices != -1)[:, :, np.newaxis],
+            np.eye(N, dtype=np.int8),
+            0
+        )
+    adj[adj > 1] = 1
+    return adj
+
+
+def get_sorted_pdg():
+    from erum_data_data import Belle
+    data = Belle.load()
+    mapped_pdg, counts = np.unique(data[0][0][:, :, -1].ravel(), return_counts=True)
+    mapped = mapped_pdg[np.argsort(counts)][::-1].astype(int)
+    return mapped[mapped != 0]
+
+
+# generated with `get_sorted_pdg()`
+sorted_pdg = [
+   506, 423, 236, 143, 321, 171, 323,  15, 114,  19,  96, 394, 372,
+    46,  44, 190, 134, 141, 375,   8, 337, 220, 415, 248, 249,  11,
+    34, 434, 263,   4, 126, 378, 418, 183, 182,  10, 245,  85,  45,
+   210, 178, 139, 275, 322, 419, 121, 437,  42, 118, 424, 480, 483,
+    79, 414,  61, 393,  38, 349, 108,  86,  32, 357, 238, 173, 305,
+    57, 413, 491, 158, 355,  78, 176, 164, 352, 187, 205, 471,  71,
+   458, 350, 101, 280, 389, 376,  89, 120, 457, 436, 186, 444,  76,
+   390, 402, 342, 258, 391, 407, 162, 185, 152, 276, 149, 302, 106,
+   110, 401, 109, 487, 279, 192, 446, 334,  56, 359, 194, 314, 202,
+   420, 208, 427, 475, 495, 465, 442, 489, 360, 448, 216, 215, 300,
+   214,  13, 227, 501, 502, 399, 344, 474, 150,  53, 325, 129, 326,
+   195, 366, 370, 336, 163, 154,  66, 105, 285, 473, 455, 421,  43,
+   119, 271, 373, 363, 428, 304, 229, 425, 133, 270, 219, 479, 112,
+   250, 217,  33, 403, 338, 206,  39, 268, 130, 328,  93, 346, 212
+]
+
+
+def remap_pdg(mapped_pdg):
+    """
+    Remap mapped pdg ids again for later one-hot encoding to `num_pdg`
+    number of dimensions. They are sorted by number of occurence.
+    """
+
+    remap_dict = {v : k for k, v in enumerate(sorted_pdg)}
+
+    @np.vectorize
+    def remap(pdg_id):
+        return remap_dict.get(pdg_id, len(sorted_pdg) + 1)
+
+    return remap(mapped_pdg)
+
+
+def np_onehot(indices, depth):
+    """
+    Behaviour like tf.one_hot
+    """
+    indices = np.array(indices)
+    indices[indices >= depth] = depth
+    return np.eye(depth + 1, dtype=np.int8)[indices][..., :-1]

--- a/erum_data_data/belle_graph_utils.py
+++ b/erum_data_data/belle_graph_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 
 """
 Some helper functions for the graph version of the Belle dataset
@@ -28,6 +27,8 @@ def adjacency_matrix_from_mothers_tf(mother_indices, symmetrize=True, add_diagon
     """
     Like `adjacency_matrix_from_mothers_np`, but using tensorflow
     """
+    import tensorflow as tf
+
     shape = tf.shape(mother_indices)
     N = shape[1]
     bs = shape[0]

--- a/erum_data_data/erum_data_data.py
+++ b/erum_data_data/erum_data_data.py
@@ -154,3 +154,4 @@ class Belle(Dataset):
     filename = "6_belle_selective_400k.npz"
     url = "https://desycloud.desy.de/index.php/s/RKB4z3mMcPPY982/download"
     md5 = "85b10c9df3903455ab247a0ab4b51e5f"
+    load_graph = LoadGraph.belle_graph

--- a/erum_data_data/erum_data_data.py
+++ b/erum_data_data/erum_data_data.py
@@ -155,3 +155,4 @@ class Belle(Dataset):
     url = "https://desycloud.desy.de/index.php/s/RKB4z3mMcPPY982/download"
     md5 = "85b10c9df3903455ab247a0ab4b51e5f"
     load_graph = LoadGraph.belle_graph
+    load_graph_tf_data = lambda *args, **kwargs: LoadGraph.belle_graph(*args, **kwargs, as_tf_data=True)

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 from .tt_graph_utils import load_top, convert
 from . import belle_graph_utils as _belle
 
@@ -114,6 +113,8 @@ class LoadGraph:
             )
             return X_graph, y
         else:
+
+            import tensorflow as tf
 
             def tensor_slices(slicing):
                 return {

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -99,7 +99,7 @@ class LoadGraph:
             y = y[:max_entries]
 
         X_graph = {}
-        X_graph['adjacency'] = _belle.adjacency_matrix_from_mothers_np(X[1].astype(np.int8))
+        X_graph['adj_matrix'] = _belle.adjacency_matrix_from_mothers_np(X[1].astype(np.int8))
         X_graph['features'] = np.concatenate(
             [
                 X[0][:, :, :-1],

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -179,3 +179,25 @@ def _adjacency_matrix_img(inputs):
             adj[i][i-1] = 1
     adj = np.broadcast_to(adj, [bs, N, N])
     return adj
+
+
+def test_belle_graphs_tf_np_consistency():
+
+    from collections import defaultdict
+
+    max_entries = 1000
+    x_train, y_train = LoadGraph.belle_graph('train', path = './datasets', max_entries=max_entries)
+    ds_train = LoadGraph.belle_graph(
+        'train',
+        path = './datasets',
+        validation_split=None,
+        max_entries=max_entries,
+        batch_size=64,
+        as_tf_data=True
+    )
+    x_train_tf = defaultdict(list)
+    for batch in ds_train:
+        for k in x_train:
+            x_train_tf[k].append(batch[0][k].numpy())
+    for k in x_train_tf:
+        assert (x_train[k] == np.concatenate(x_train_tf[k])).all()

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .tt_graph_utils import load_top, convert
+from . import belle_graph_utils as _belle
 
 
 class LoadGraph:
@@ -98,16 +99,17 @@ class LoadGraph:
             y = y[:max_entries]
 
         X_graph = {}
-        X_graph['adjacency'] = _Belle.adjacency_matrix_from_mothers_np(X[1].astype(np.int8))
+        X_graph['adjacency'] = _belle.adjacency_matrix_from_mothers_np(X[1].astype(np.int8))
         X_graph['features'] = np.concatenate(
             [
                 X[0][:, :, :-1],
-                _Belle.np_onehot(_Belle.remap_pdg(X[0][:, :, -1]), num_pdg)
+                _belle.np_onehot(_belle.remap_pdg(X[0][:, :, -1]), num_pdg)
             ],
             axis=-1
         )
 
         return X_graph, y
+
 
 def _adjacency_matrix_img(inputs):
     """
@@ -136,79 +138,3 @@ def _adjacency_matrix_img(inputs):
             adj[i][i-1] = 1
     adj = np.broadcast_to(adj, [bs, N, N])
     return adj
-
-
-class _Belle:
-
-    """
-    Some helper functions for the graph version of the Belle dataset
-    """
-
-    def adjacency_matrix_from_mothers_np(mother_indices, symmetrize=True, add_diagonal=True):
-        """
-        Calculate adjacency matrix from mother indices (numpy version). Assumes
-        that mother indices are -1 padded.
-        """
-        N = mother_indices.shape[1]
-        adj = np.eye(N + 1, dtype=np.int8)[mother_indices][:, :, :-1]
-        if symmetrize:
-            adj = adj + np.transpose(adj, (0, 2, 1))
-        if add_diagonal:
-            adj += np.where(
-                (mother_indices != -1)[:, :, np.newaxis],
-                np.eye(N, dtype=np.int8),
-                0
-            )
-        adj[adj > 1] = 1
-        return adj
-
-
-    def get_sorted_pdg():
-        from erum_data_data import Belle
-        data = Belle.load()
-        mapped_pdg, counts = np.unique(data[0][0][:, :, -1].ravel(), return_counts=True)
-        mapped = mapped_pdg[np.argsort(counts)][::-1].astype(int)
-        return mapped[mapped != 0]
-
-
-    # generated with `_Belle.get_sorted_pdg()`
-    sorted_pdg = [
-       506, 423, 236, 143, 321, 171, 323,  15, 114,  19,  96, 394, 372,
-        46,  44, 190, 134, 141, 375,   8, 337, 220, 415, 248, 249,  11,
-        34, 434, 263,   4, 126, 378, 418, 183, 182,  10, 245,  85,  45,
-       210, 178, 139, 275, 322, 419, 121, 437,  42, 118, 424, 480, 483,
-        79, 414,  61, 393,  38, 349, 108,  86,  32, 357, 238, 173, 305,
-        57, 413, 491, 158, 355,  78, 176, 164, 352, 187, 205, 471,  71,
-       458, 350, 101, 280, 389, 376,  89, 120, 457, 436, 186, 444,  76,
-       390, 402, 342, 258, 391, 407, 162, 185, 152, 276, 149, 302, 106,
-       110, 401, 109, 487, 279, 192, 446, 334,  56, 359, 194, 314, 202,
-       420, 208, 427, 475, 495, 465, 442, 489, 360, 448, 216, 215, 300,
-       214,  13, 227, 501, 502, 399, 344, 474, 150,  53, 325, 129, 326,
-       195, 366, 370, 336, 163, 154,  66, 105, 285, 473, 455, 421,  43,
-       119, 271, 373, 363, 428, 304, 229, 425, 133, 270, 219, 479, 112,
-       250, 217,  33, 403, 338, 206,  39, 268, 130, 328,  93, 346, 212
-    ]
-
-
-    def remap_pdg(mapped_pdg):
-        """
-        Remap mapped pdg ids again for later one-hot encoding to `num_pdg`
-        number of dimensions. They are sorted by number of occurence.
-        """
-
-        remap_dict = {v : k for k, v in enumerate(_Belle.sorted_pdg)}
-
-        @np.vectorize
-        def remap(pdg_id):
-            return remap_dict.get(pdg_id, len(_Belle.sorted_pdg) + 1)
-
-        return remap(mapped_pdg)
-
-
-    def np_onehot(indices, depth):
-        """
-        Behaviour like tf.one_hot
-        """
-        indices = np.array(indices)
-        indices[indices >= depth] = depth
-        return np.eye(depth + 1, dtype=np.int8)[indices][..., :-1]

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -81,12 +81,34 @@ class LoadGraph:
         return X_graph, y
         
         
-        
-        
-        
-            
-            
-        
+    def belle_graph(
+        split="train",
+        path="./datasets",
+        force_download=False,
+        num_pdg=182,
+        max_entries=None
+    ):
+        from erum_data_data import Belle
+
+        X, y = Belle.load(split, path, force_download)
+
+        if max_entries is not None:
+            # this is mainly for testing
+            X = [x_i[:max_entries] for x_i in X]
+            y = y[:max_entries]
+
+        X_graph = {}
+        X_graph['adjacency'] = _Belle.adjacency_matrix_from_mothers_np(X[1].astype(np.int8))
+        X_graph['features'] = np.concatenate(
+            [
+                X[0][:, :, :-1],
+                _Belle.np_onehot(_Belle.remap_pdg(X[0][:, :, -1]), num_pdg)
+            ],
+            axis=-1
+        )
+
+        return X_graph, y
+
 def _adjacency_matrix_img(inputs):
     """
     calculate adjacency matrix for images
@@ -113,6 +135,80 @@ def _adjacency_matrix_img(inputs):
             adj[i-1][i] = 1
             adj[i][i-1] = 1
     adj = np.broadcast_to(adj, [bs, N, N])
-    return adj  
+    return adj
 
 
+class _Belle:
+
+    """
+    Some helper functions for the graph version of the Belle dataset
+    """
+
+    def adjacency_matrix_from_mothers_np(mother_indices, symmetrize=True, add_diagonal=True):
+        """
+        Calculate adjacency matrix from mother indices (numpy version). Assumes
+        that mother indices are -1 padded.
+        """
+        N = mother_indices.shape[1]
+        adj = np.eye(N + 1, dtype=np.int8)[mother_indices][:, :, :-1]
+        if symmetrize:
+            adj = adj + np.transpose(adj, (0, 2, 1))
+        if add_diagonal:
+            adj += np.where(
+                (mother_indices != -1)[:, :, np.newaxis],
+                np.eye(N, dtype=np.int8),
+                0
+            )
+        adj[adj > 1] = 1
+        return adj
+
+
+    def get_sorted_pdg():
+        from erum_data_data import Belle
+        data = Belle.load()
+        mapped_pdg, counts = np.unique(data[0][0][:, :, -1].ravel(), return_counts=True)
+        mapped = mapped_pdg[np.argsort(counts)][::-1].astype(int)
+        return mapped[mapped != 0]
+
+
+    # generated with `_Belle.get_sorted_pdg()`
+    sorted_pdg = [
+       506, 423, 236, 143, 321, 171, 323,  15, 114,  19,  96, 394, 372,
+        46,  44, 190, 134, 141, 375,   8, 337, 220, 415, 248, 249,  11,
+        34, 434, 263,   4, 126, 378, 418, 183, 182,  10, 245,  85,  45,
+       210, 178, 139, 275, 322, 419, 121, 437,  42, 118, 424, 480, 483,
+        79, 414,  61, 393,  38, 349, 108,  86,  32, 357, 238, 173, 305,
+        57, 413, 491, 158, 355,  78, 176, 164, 352, 187, 205, 471,  71,
+       458, 350, 101, 280, 389, 376,  89, 120, 457, 436, 186, 444,  76,
+       390, 402, 342, 258, 391, 407, 162, 185, 152, 276, 149, 302, 106,
+       110, 401, 109, 487, 279, 192, 446, 334,  56, 359, 194, 314, 202,
+       420, 208, 427, 475, 495, 465, 442, 489, 360, 448, 216, 215, 300,
+       214,  13, 227, 501, 502, 399, 344, 474, 150,  53, 325, 129, 326,
+       195, 366, 370, 336, 163, 154,  66, 105, 285, 473, 455, 421,  43,
+       119, 271, 373, 363, 428, 304, 229, 425, 133, 270, 219, 479, 112,
+       250, 217,  33, 403, 338, 206,  39, 268, 130, 328,  93, 346, 212
+    ]
+
+
+    def remap_pdg(mapped_pdg):
+        """
+        Remap mapped pdg ids again for later one-hot encoding to `num_pdg`
+        number of dimensions. They are sorted by number of occurence.
+        """
+
+        remap_dict = {v : k for k, v in enumerate(_Belle.sorted_pdg)}
+
+        @np.vectorize
+        def remap(pdg_id):
+            return remap_dict.get(pdg_id, len(_Belle.sorted_pdg) + 1)
+
+        return remap(mapped_pdg)
+
+
+    def np_onehot(indices, depth):
+        """
+        Behaviour like tf.one_hot
+        """
+        indices = np.array(indices)
+        indices[indices >= depth] = depth
+        return np.eye(depth + 1, dtype=np.int8)[indices][..., :-1]

--- a/erum_data_data/graphs.py
+++ b/erum_data_data/graphs.py
@@ -142,10 +142,13 @@ class LoadGraph:
                     .map(transform)
                 )
 
-            split_at = int(len(y) * (1 - validation_split))
-            ds_train = from_tensor_slices(slice(None, split_at))
-            ds_val = from_tensor_slices(slice(split_at, None))
-            return ds_train, ds_val
+            if validation_split is not None:
+                split_at = int(len(y) * (1 - validation_split))
+                ds_train = from_tensor_slices(slice(None, split_at))
+                ds_val = from_tensor_slices(slice(split_at, None))
+                return ds_train, ds_val
+            else:
+                return from_tensor_slices(slice(None))
 
 
 def _adjacency_matrix_img(inputs):

--- a/graph_models/main_graph.py
+++ b/graph_models/main_graph.py
@@ -10,8 +10,6 @@ from utils import test_accuracy
 from utils import test_f1_score
 
 from os import chdir
-import numpy as np
-import tensorflow as tf
 #########################################
 #####  EXAMPLE IMPLEMENTATION OF FCN  ###
 
@@ -19,50 +17,24 @@ nn = Network()
 
 datasets = nn.compatible_datasets
 
-# set to true to cache tf data datasets
-# (if enough memory is available)
-cache_tf_data = True
-
 for ds in datasets:
 
-    if not hasattr(ds, "load_graph_tf_data"):
-        x_train, y_train = ds.load_graph('train', path = './datasets')
-        x_test, y_test = ds.load_graph('test', path = './datasets')
-        model = nn.model(ds, shapes=nn.get_shapes(x_train))
-        model.compile(**nn.compile_args)
-        print(model.summary())
-        history = model.fit(x=x_train, y=y_train, **nn.fit_args)
-        y_pred = model.predict(x_test).ravel()
-    else:
-        fit_args = dict(nn.fit_args)
-        batch_args = dict(
-            validation_split=fit_args.pop("validation_split"),
-            batch_size=fit_args.pop("batch_size")
-        )
-        tf_ds_train, tf_ds_val = ds.load_graph_tf_data('train', path = './datasets', **batch_args)
-        tf_ds_test = ds.load_graph_tf_data('test', path = './datasets', **dict(batch_args, validation_split=None))
-        example_batch = next(iter(tf_ds_train))
-        model = nn.model(ds, shapes=nn.get_shapes(example_batch[0]))
-        model.compile(**nn.compile_args)
-        print(model.summary())
-        if not cache_tf_data:
-            history = model.fit(tf_ds_train, validation_data=tf_ds_val, **fit_args)
-        else:
-            history = model.fit(
-                tf_ds_train.cache().repeat(),
-                validation_data=tf_ds_val.cache().repeat(),
-                steps_per_epoch=int(tf.data.experimental.cardinality(tf_ds_train)),
-                validation_steps=int(tf.data.experimental.cardinality(tf_ds_val)),
-                **fit_args
-            )
-        y_pred = model.predict(tf_ds_test.map(lambda x, y: x)).ravel()
-        y_test = np.concatenate([batch.numpy() for batch in tf_ds_test.map(lambda x, y: y)])
+    x_train, y_train = ds.load_graph('train', path = './datasets')
+
+    x_test, y_test = ds.load_graph('test', path = './datasets')
+    
+    model = nn.model(ds, shapes=nn.get_shapes(x_train))
+    model.compile(**nn.compile_args)
+    print(model.summary())
+    history = model.fit(x=x_train, y=y_train, **nn.fit_args)
 
     ##	From here on, one should be able to use already defined methods as showed in the following lines.
     ##	Let us know if you face any issues with that.
 
+    # training history plots
     label = '_test_graph'
-
+    # evaluation plots and scores
+    y_pred = model.predict(x_test).ravel()
     test_accuracy(y_pred, y_test, ds.name+label, nn.model_name)
     test_f1_score(y_pred, y_test, ds.name+label, nn.model_name)
 

--- a/graph_models/main_graph.py
+++ b/graph_models/main_graph.py
@@ -10,12 +10,18 @@ from utils import test_accuracy
 from utils import test_f1_score
 
 from os import chdir
+import numpy as np
+import tensorflow as tf
 #########################################
 #####  EXAMPLE IMPLEMENTATION OF FCN  ###
 
 nn = Network()
 
 datasets = nn.compatible_datasets
+
+# set to true to cache tf data datasets
+# (if enough memory is available)
+cache_tf_data = True
 
 for ds in datasets:
 
@@ -34,14 +40,23 @@ for ds in datasets:
             batch_size=fit_args.pop("batch_size")
         )
         tf_ds_train, tf_ds_val = ds.load_graph_tf_data('train', path = './datasets', **batch_args)
-        tf_ds_test = ds.load_graph_tf_data('test', path = './datasets', **batch_args)
+        tf_ds_test = ds.load_graph_tf_data('test', path = './datasets', **dict(batch_args, validation_split=None))
         example_batch = next(iter(tf_ds_train))
         model = nn.model(ds, shapes=nn.get_shapes(example_batch[0]))
         model.compile(**nn.compile_args)
         print(model.summary())
-        history = model.fit(tf_ds_train, validation_data=tf_ds_val, **fit_args)
-        y_pred = model.predict(ds_test.map(lambda x, y: x)).ravel()
-        y_test = np.concatenate([batch.numpy() for batch in ds_val.map(lambda x, y: y)])
+        if not cache_tf_data:
+            history = model.fit(tf_ds_train, validation_data=tf_ds_val, **fit_args)
+        else:
+            history = model.fit(
+                tf_ds_train.cache().repeat(),
+                validation_data=tf_ds_val.cache().repeat(),
+                steps_per_epoch=int(tf.data.experimental.cardinality(tf_ds_train)),
+                validation_steps=int(tf.data.experimental.cardinality(tf_ds_val)),
+                **fit_args
+            )
+        y_pred = model.predict(tf_ds_test.map(lambda x, y: x)).ravel()
+        y_test = np.concatenate([batch.numpy() for batch in tf_ds_test.map(lambda x, y: y)])
 
     ##	From here on, one should be able to use already defined methods as showed in the following lines.
     ##	Let us know if you face any issues with that.

--- a/graph_models/main_graph.py
+++ b/graph_models/main_graph.py
@@ -19,22 +19,35 @@ datasets = nn.compatible_datasets
 
 for ds in datasets:
 
-    x_train, y_train = ds.load_graph('train', path = './datasets')
-
-    x_test, y_test = ds.load_graph('test', path = './datasets')
-    
-    model = nn.model(ds, shapes=nn.get_shapes(x_train))
-    model.compile(**nn.compile_args)
-    print(model.summary())
-    history = model.fit(x=x_train, y=y_train, **nn.fit_args)
+    if not hasattr(ds, "load_graph_tf_data"):
+        x_train, y_train = ds.load_graph('train', path = './datasets')
+        x_test, y_test = ds.load_graph('test', path = './datasets')
+        model = nn.model(ds, shapes=nn.get_shapes(x_train))
+        model.compile(**nn.compile_args)
+        print(model.summary())
+        history = model.fit(x=x_train, y=y_train, **nn.fit_args)
+        y_pred = model.predict(x_test).ravel()
+    else:
+        fit_args = dict(nn.fit_args)
+        batch_args = dict(
+            validation_split=fit_args.pop("validation_split"),
+            batch_size=fit_args.pop("batch_size")
+        )
+        tf_ds_train, tf_ds_val = ds.load_graph_tf_data('train', path = './datasets', **batch_args)
+        tf_ds_test = ds.load_graph_tf_data('test', path = './datasets', **batch_args)
+        example_batch = next(iter(tf_ds_train))
+        model = nn.model(ds, shapes=nn.get_shapes(example_batch[0]))
+        model.compile(**nn.compile_args)
+        print(model.summary())
+        history = model.fit(tf_ds_train, validation_data=tf_ds_val, **fit_args)
+        y_pred = model.predict(ds_test.map(lambda x, y: x)).ravel()
+        y_test = np.concatenate([batch.numpy() for batch in ds_val.map(lambda x, y: y)])
 
     ##	From here on, one should be able to use already defined methods as showed in the following lines.
     ##	Let us know if you face any issues with that.
 
-    # training history plots
     label = '_test_graph'
-    # evaluation plots and scores
-    y_pred = model.predict(x_test).ravel()
+
     test_accuracy(y_pred, y_test, ds.name+label, nn.model_name)
     test_f1_score(y_pred, y_test, ds.name+label, nn.model_name)
 

--- a/graph_models/simple_graph_net.py
+++ b/graph_models/simple_graph_net.py
@@ -6,7 +6,7 @@ import awkward
 import uproot_methods
 
 from template import NetworkABC
-from erum_data_data.erum_data_data import TopTagging, Spinodal, EOSL
+from erum_data_data.erum_data_data import TopTagging, Spinodal, EOSL, Belle
 
 def lr_schedule(epoch):
     lr = 1e-3
@@ -54,7 +54,7 @@ class Network(NetworkABC):
                 'callbacks': callbacks
                }                      ##dictionary of the arguments to be passed to the method fit()
 
-    compatible_datasets = [EOSL]          ## we would also ask you to add a list of the datasets that would be compatible with your implementation 
+    compatible_datasets = [Belle]          ## we would also ask you to add a list of the datasets that would be compatible with your implementation 
 
     '''
     def preprocessing(self, X):


### PR DESCRIPTION
I had to experiment a bit to get this running without out-of-memory errors.

First, the adjacency matrices seem fine, they can be loaded into a `int8` array, so they don't use that much memory. A bit more problematic is one-hot encoding of the pdg ids (in the original reference model i used an embedding layer instead). Those are now concatenated with the other features, which are `float32`, so they use 4x the memory (and i would like to go for 182 different pdg ids as there are that many in the training dataset).

Of course i could go for a lower number of dimensions, and in fact i have tried this out and found something in the range of the top 10-50 pdg ids might be sufficient:

![image](https://user-images.githubusercontent.com/3707225/110134965-476d1c00-7dce-11eb-8405-bd805e7862ef.png)

But that would be boring right? :wink: Especially since the plot shows that it worked to train also with 182 (and was in fact still pretty fast).

So first what is the memory problem - it seems that keras tries to load the **whole** dataset into GPU memory when just calling `.fit` with the numpy array. I got an out of memory error for a V100 with 32GB of GPU memory and that can't be due to the data of one batch (even with batch size 1024 that should be much less).

Loading the data with `tf.data.Dataset.from_tensor_slices` seems to solve that actually, but when i already do this i (foolishly) thought i could as well do the transformation (creating adjacency matrix and one-hot encoding) using `tf.data`. So after fiddling around a lot i got it running. It is actually reasonably fast, but can be made even a factor of 2 faster by caching the data again in memory (great now i turned in a circle). Peak (CPU) memory usage is then around 35GB, so that's fine for most setups this is going to run on.

Performance is very close to the reference model (as it should be since the only real difference is the one-hot encoding of the pdg ids instead of embedding):

![image](https://user-images.githubusercontent.com/3707225/110136355-e2b2c100-7dcf-11eb-87dc-7d6373e07e1f.png)

So in order to test this i introduced a switch in the graph training script that checks for the existence of a `load_graph_tf_data
` in which case it will run the training by passing the `tf.data` datasets to keras. There is another hard-coded flag `cache_tf_data` to decide whether or not to cache the transformed data in memory after one full iteration.

There is still the possibility to do the transformation on the whole dataset using numpy, but as said i haven't managed to run the training for that yet when using the full dataset.

Of course i introduced quite a bit of mess with this, so let me know if you think it makes sense to keep that - otherwise i think it would also be reasonable to go with reducing the number of pdg id dimensions until it fits into GPU memory. Or alternatively doing a simpler `tf.data` wrapper around the numpy datasets in general to ensure only one batch at a time gets loaded into GPU memory.

You know what? I wanted to write down the following reproducer for the out-of-GPU-memory problem in non-tf-data mode:
```python
from erum_data_data import Belle
from simple_graph_net import Network
nn = Network()
ds = Belle
x_train, y_train = ds.load_graph('train', path = './datasets')
model = nn.model(ds, shapes=nn.get_shapes(x_train))
model.compile(loss="binary_crossentropy", optimizer="adam")
model.fit(x_train, y_train, batch_size=1024)
```
... but it actually runs just fine, using up only a small amount of GPU memory (1.5 GB). It was great talking to you rubber duck, let me figure out what the problem was before or if it actually just works ...